### PR TITLE
Android: Add support for custom tabs customization

### DIFF
--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -3,7 +3,9 @@ package dev.vbonnet.flutterwebbrowser;
 import android.app.Activity;
 import android.graphics.Color;
 import android.net.Uri;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
+import java.util.HashMap;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -34,13 +36,39 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
       return;
     }
     String url = call.argument("url");
-    String toolbarColorArg = call.argument("android_toolbar_color");
+    HashMap<String, Object> options = call.<HashMap<String, Object>>argument("android_options");
 
     CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-    if (toolbarColorArg != null) {
-      int toolbarColor = Color.parseColor(toolbarColorArg);
-      builder.setToolbarColor(toolbarColor);
+
+    builder.setColorScheme((Integer) options.get("colorScheme"));
+
+    String navigationBarColor = (String)options.get("navigationBarColor");
+    if (navigationBarColor != null) {
+      builder.setNavigationBarColor(Color.parseColor(navigationBarColor));
     }
+
+    String toolbarColor = (String)options.get("toolbarColor");
+    if (toolbarColor != null) {
+      builder.setToolbarColor(Color.parseColor(toolbarColor));
+    }
+
+    String secondaryToolbarColor = (String)options.get("secondaryToolbarColor");
+    if (secondaryToolbarColor != null) {
+      builder.setSecondaryToolbarColor(Color.parseColor(secondaryToolbarColor));
+    }
+
+    builder.setInstantAppsEnabled((Boolean) options.get("instantAppsEnabled"));
+
+    if ((Boolean) options.get("addDefaultShareMenuItem")) {
+      builder.addDefaultShareMenuItem();
+    }
+
+    builder.setShowTitle((Boolean) options.get("showTitle"));
+
+    if ((Boolean) options.get("urlBarHidingEnabled")) {
+      builder.enableUrlBarHiding();
+    }
+
     CustomTabsIntent customTabsIntent = builder.build();
     customTabsIntent.launchUrl(activity, Uri.parse(url));
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,8 +14,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   openBrowserTab() async {
-    await FlutterWebBrowser.openWebPage(
-        url: "https://flutter.io/", androidToolbarColor: Colors.deepPurple);
+    await FlutterWebBrowser.openWebPage(url: "https://flutter.io/");
   }
 
   @override
@@ -33,13 +32,33 @@ class _MyAppState extends State<MyApp> {
                 onPressed: () => openBrowserTab(),
                 child: new Text('Open Flutter website'),
               ),
+              if (Platform.isAndroid) ...[
+                Text('test Android customizations'),
+                RaisedButton(
+                  onPressed: () {
+                    FlutterWebBrowser.openWebPage(
+                      url: "https://flutter.io/",
+                      customTabsOptions: CustomTabsOptions(
+                        colorScheme: CustomTabsColorScheme.dark,
+                        toolbarColor: Colors.deepPurple,
+                        secondaryToolbarColor: Colors.green,
+                        navigationBarColor: Colors.amber,
+                        addDefaultShareMenuItem: true,
+                        instantAppsEnabled: true,
+                        showTitle: true,
+                        urlBarHidingEnabled: true,
+                      ),
+                    );
+                  },
+                  child: Text('Open Flutter website'),
+                ),
+              ],
               if (Platform.isIOS) ...[
                 Text('test iOS customizations'),
                 RaisedButton(
                   onPressed: () {
                     FlutterWebBrowser.openWebPage(
                       url: "https://flutter.io/",
-                      androidToolbarColor: Colors.deepPurple,
                       safariVCOptions: SafariViewControllerOptions(
                         barCollapsingEnabled: true,
                         preferredBarTintColor: Colors.green,

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -27,6 +27,34 @@ class SafariViewControllerOptions {
   });
 }
 
+enum CustomTabsColorScheme {
+  system, // 0x00000000
+  light, // 0x00000001
+  dark, // 0x00000002
+}
+
+class CustomTabsOptions {
+  final CustomTabsColorScheme colorScheme;
+  final Color toolbarColor;
+  final Color secondaryToolbarColor;
+  final Color navigationBarColor;
+  final bool instantAppsEnabled;
+  final bool addDefaultShareMenuItem;
+  final bool showTitle;
+  final bool urlBarHidingEnabled;
+
+  const CustomTabsOptions({
+    this.colorScheme = CustomTabsColorScheme.system,
+    this.toolbarColor,
+    this.secondaryToolbarColor,
+    this.navigationBarColor,
+    this.instantAppsEnabled = false,
+    this.addDefaultShareMenuItem = false,
+    this.showTitle = false,
+    this.urlBarHidingEnabled = false,
+  });
+}
+
 extension _hexColor on Color {
   /// Returns the color value as ARGB hex value.
   String get hexColor {
@@ -40,21 +68,41 @@ class FlutterWebBrowser {
 
   static Future<dynamic> openWebPage({
     String url,
-    Color androidToolbarColor,
+    CustomTabsOptions customTabsOptions = const CustomTabsOptions(),
     SafariViewControllerOptions safariVCOptions =
         const SafariViewControllerOptions(),
+    @Deprecated("Use customTabsOptions instead") Color androidToolbarColor,
   }) {
     assert(url != null);
+    assert(customTabsOptions != null);
     assert(safariVCOptions != null);
 
-    var hexColor;
     if (androidToolbarColor != null) {
-      hexColor = androidToolbarColor?.hexColor;
+      customTabsOptions = CustomTabsOptions(
+        colorScheme: customTabsOptions.colorScheme,
+        toolbarColor: androidToolbarColor,
+        secondaryToolbarColor: customTabsOptions.secondaryToolbarColor,
+        navigationBarColor: customTabsOptions.navigationBarColor,
+        instantAppsEnabled: customTabsOptions.instantAppsEnabled,
+        addDefaultShareMenuItem: customTabsOptions.addDefaultShareMenuItem,
+        showTitle: customTabsOptions.showTitle,
+        urlBarHidingEnabled: customTabsOptions.urlBarHidingEnabled,
+      );
     }
 
     return _channel.invokeMethod('openWebPage', {
       "url": url,
-      "android_toolbar_color": hexColor,
+      'android_options': {
+        'colorScheme': customTabsOptions.colorScheme.index,
+        'navigationBarColor': customTabsOptions.navigationBarColor?.hexColor,
+        'toolbarColor': customTabsOptions.toolbarColor?.hexColor,
+        'secondaryToolbarColor':
+            customTabsOptions.secondaryToolbarColor?.hexColor,
+        'instantAppsEnabled': customTabsOptions.instantAppsEnabled,
+        'addDefaultShareMenuItem': customTabsOptions.addDefaultShareMenuItem,
+        'showTitle': customTabsOptions.showTitle,
+        'urlBarHidingEnabled': customTabsOptions.urlBarHidingEnabled,
+      },
       'ios_options': {
         'barCollapsingEnabled': safariVCOptions.barCollapsingEnabled,
         'entersReaderIfAvailable': safariVCOptions.entersReaderIfAvailable,


### PR DESCRIPTION
I added the `customTabsOptions` parameter for an advanced customization of the android custom tabs. I have also deprecated `androidToolbarColor`, so people will switch to using the new option. However, it will still work and show the browser windows with the adjusted color if specified, so this should be a non API-breaking change.