### PR TITLE
Android: Browser selection improvements

### DIFF
--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -28,6 +28,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
         break;
       case "warmup":
         warmup(result);
+        break;
       default:
         result.notImplemented();
         break;

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -24,6 +24,8 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
       case "openWebPage":
         openUrl(call, result);
         break;
+      case "warmup":
+        warmup(result);
       default:
         result.notImplemented();
         break;
@@ -45,10 +47,18 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     }
 
     CustomTabsIntent customTabsIntent = builder.build();
-    String packageName = CustomTabsClient.getPackageName(activity, Arrays.asList("com.android.chrome"));
-    customTabsIntent.intent.setPackage(packageName);
+    customTabsIntent.intent.setPackage(getPackageName());
     customTabsIntent.launchUrl(activity, Uri.parse(url));
 
     result.success(null);
+  }
+
+  private void warmup(Result result) {
+    boolean success = CustomTabsClient.connectAndInitialize(activity, getPackageName());
+    result.success(success);
+  }
+
+  private String getPackageName() {
+    return CustomTabsClient.getPackageName(activity, Arrays.asList("com.android.chrome"));
   }
 }

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -3,7 +3,9 @@ package dev.vbonnet.flutterwebbrowser;
 import android.app.Activity;
 import android.graphics.Color;
 import android.net.Uri;
+import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
+import java.util.Arrays;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -41,7 +43,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
       int toolbarColor = Color.parseColor(toolbarColorArg);
       builder.setToolbarColor(toolbarColor);
     }
+
     CustomTabsIntent customTabsIntent = builder.build();
+    String packageName = CustomTabsClient.getPackageName(activity, Arrays.asList("com.android.chrome"));
+    customTabsIntent.intent.setPackage(packageName);
     customTabsIntent.launchUrl(activity, Uri.parse(url));
 
     result.success(null);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,10 @@ class _MyAppState extends State<MyApp> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               RaisedButton(
+                onPressed: () => FlutterWebBrowser.warmup(),
+                child: new Text('Warmup browser website'),
+              ),
+              RaisedButton(
                 onPressed: () => openBrowserTab(),
                 child: new Text('Open Flutter website'),
               ),

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -69,6 +69,8 @@
             [[UIApplication sharedApplication] openURL:URL];
         }
         result(nil);
+    } else if ([@"warmup" isEqualToString:call.method]) {
+        result(YES);
     } else {
         result(FlutterMethodNotImplemented);
     }

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -21,7 +21,6 @@
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"openWebPage" isEqualToString:call.method]) {
         NSString *url = call.arguments[@"url"];
-        NSString *toolbarColorArg = call.arguments[@"toolbar_color"];
         NSString *controlColorArg = call.arguments[@"ios_control_color"];
         NSURL *URL = [NSURL URLWithString:url];
         UIViewController *viewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
@@ -70,7 +69,7 @@
         }
         result(nil);
     } else if ([@"warmup" isEqualToString:call.method]) {
-        result(YES);
+        result([NSNumber numberWithBool:YES]);
     } else {
         result(FlutterMethodNotImplemented);
     }

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -38,6 +38,10 @@ class FlutterWebBrowser {
   static const MethodChannel _channel =
       const MethodChannel('flutter_web_browser');
 
+  static Future<bool> warmup() {
+    return _channel.invokeMethod<bool>('warmup');
+  }
+
   static Future<dynamic> openWebPage({
     String url,
     Color androidToolbarColor,


### PR DESCRIPTION
This PR adds 2 improvements. I created a single PR since they depend on each other. If prefered, I can split it into two:

1. If the users default browser does not support custom tabs, the library will now try to fallback to using google chrome. If chrome is not installed, the default browser will be opened instead as seperate activity.
2. Added `FlutterWebBrowser.warmup()`, which will warmup the browser engine used to open a custom tab, leading to much faster page loading. Does nothing on iOS