### PR TITLE
Adds redirect & close events via iOS delegate

### DIFF
--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -19,16 +20,24 @@ class _MyAppState extends State<MyApp> {
 
   List<BrowserEvent> _events = [];
 
+  StreamSubscription<BrowserEvent>? _browserEvents;
+
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
 
-    FlutterWebBrowser.events().listen((event) {
+    _browserEvents = FlutterWebBrowser.events().listen((event) {
       setState(() {
         _events.add(event);
       });
     });
+  }
+
+  @override
+  void dispose() {
+    _browserEvents?.cancel();
+
+    super.dispose();
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,8 +13,22 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  openBrowserTab() async {
+  Future<void> openBrowserTab() async {
     await FlutterWebBrowser.openWebPage(url: "https://flutter.io/");
+  }
+
+  List<BrowserEvent> _events = [];
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+
+    FlutterWebBrowser.events().listen((event) {
+      setState(() {
+        _events.add(event);
+      });
+    });
   }
 
   @override
@@ -25,57 +39,84 @@ class _MyAppState extends State<MyApp> {
           title: new Text('Plugin example app'),
         ),
         body: new Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              RaisedButton(
-                onPressed: () => FlutterWebBrowser.warmup(),
-                child: new Text('Warmup browser website'),
-              ),
-              RaisedButton(
-                onPressed: () => openBrowserTab(),
-                child: new Text('Open Flutter website'),
-              ),
-              if (Platform.isAndroid) ...[
-                Text('test Android customizations'),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
                 RaisedButton(
-                  onPressed: () {
-                    FlutterWebBrowser.openWebPage(
-                      url: "https://flutter.io/",
-                      customTabsOptions: CustomTabsOptions(
-                        colorScheme: CustomTabsColorScheme.dark,
-                        toolbarColor: Colors.deepPurple,
-                        secondaryToolbarColor: Colors.green,
-                        navigationBarColor: Colors.amber,
-                        addDefaultShareMenuItem: true,
-                        instantAppsEnabled: true,
-                        showTitle: true,
-                        urlBarHidingEnabled: true,
-                      ),
-                    );
-                  },
-                  child: Text('Open Flutter website'),
+                  onPressed: () => FlutterWebBrowser.warmup(),
+                  child: new Text('Warmup browser website'),
                 ),
+                RaisedButton(
+                  onPressed: () => openBrowserTab(),
+                  child: new Text('Open Flutter website'),
+                ),
+                RaisedButton(
+                  onPressed: () => openBrowserTab().then(
+                    (value) => Future.delayed(
+                      Duration(seconds: 5),
+                      () => FlutterWebBrowser.close(),
+                    ),
+                  ),
+                  child:
+                      new Text('Open Flutter website & close after 5 seconds'),
+                ),
+                if (Platform.isAndroid) ...[
+                  Text('test Android customizations'),
+                  RaisedButton(
+                    onPressed: () {
+                      FlutterWebBrowser.openWebPage(
+                        url: "https://flutter.io/",
+                        customTabsOptions: CustomTabsOptions(
+                          colorScheme: CustomTabsColorScheme.dark,
+                          toolbarColor: Colors.deepPurple,
+                          secondaryToolbarColor: Colors.green,
+                          navigationBarColor: Colors.amber,
+                          addDefaultShareMenuItem: true,
+                          instantAppsEnabled: true,
+                          showTitle: true,
+                          urlBarHidingEnabled: true,
+                        ),
+                      );
+                    },
+                    child: Text('Open Flutter website'),
+                  ),
+                ],
+                if (Platform.isIOS) ...[
+                  Text('test iOS customizations'),
+                  RaisedButton(
+                    onPressed: () {
+                      FlutterWebBrowser.openWebPage(
+                        url: "https://flutter.io/",
+                        safariVCOptions: SafariViewControllerOptions(
+                          barCollapsingEnabled: true,
+                          preferredBarTintColor: Colors.green,
+                          preferredControlTintColor: Colors.amber,
+                          dismissButtonStyle:
+                              SafariViewControllerDismissButtonStyle.close,
+                          modalPresentationCapturesStatusBarAppearance: true,
+                        ),
+                      );
+                    },
+                    child: Text('Open Flutter website'),
+                  ),
+                  Divider(),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: _events.map((e) {
+                      if (e is RedirectEvent) {
+                        return Text('redirect: ${e.url}');
+                      }
+                      if (e is CloseEvent) {
+                        return Text('closed');
+                      }
+
+                      return Text('Unknown event: $e');
+                    }).toList(),
+                  ),
+                ]
               ],
-              if (Platform.isIOS) ...[
-                Text('test iOS customizations'),
-                RaisedButton(
-                  onPressed: () {
-                    FlutterWebBrowser.openWebPage(
-                      url: "https://flutter.io/",
-                      safariVCOptions: SafariViewControllerOptions(
-                        barCollapsingEnabled: true,
-                        preferredBarTintColor: Colors.green,
-                        preferredControlTintColor: Colors.amber,
-                        dismissButtonStyle: SafariViewControllerDismissButtonStyle.close,
-                        modalPresentationCapturesStatusBarAppearance: true,
-                      ),
-                    );
-                  },
-                  child: Text('Open Flutter website'),
-                ),
-              ]
-            ],
+            ),
           ),
         ),
       ),

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -85,18 +85,18 @@
     } else if ([@"warmup" isEqualToString:call.method]) {
         result([NSNumber numberWithBool:YES]);
     } else if ([@"close" isEqualToString:call.method]) {
-      if (_currentController) {
-        [_currentController dismissViewControllerAnimated:YES completion:nil];
+        if (_currentController) {
+            [_currentController dismissViewControllerAnimated:YES completion:nil];
 
-        // SafariViewController does not emit the `safariViewControllerDidFinish` when dismissed.
-        if (_eventSink) {
-          _eventSink(@{
-            @"event": @"close",
-          });
+            // SafariViewController does not call `safariViewControllerDidFinish` when dismissed manually,
+            // therefore a manual close event needs to be emitted.
+            if (_eventSink) {
+                _eventSink(@{ @"event": @"close" });
+            }
+
+            _currentController = nil;
         }
-
-      }
-      result(nil);
+        result(nil);
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -119,22 +119,20 @@
 #pragma mark - SFSafariViewControllerDelegate
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-  _currentController = nil;
-  
-  if (_eventSink) {
-    _eventSink(@{
-      @"event": @"close",
-    });
-  }
+    _currentController = nil;
+
+    if (_eventSink) {
+        _eventSink(@{ @"event": @"close" });
+    }
 }
 
 - (void)safariViewController:(SFSafariViewController *)controller initialLoadDidRedirectToURL:(NSURL *)URL {
-  if (_eventSink) {
-    _eventSink(@{
-      @"event": @"redirect",
-      @"url": URL.absoluteString
-    });
-  }
+    if (_eventSink) {
+        _eventSink(@{
+            @"event": @"redirect",
+            @"url": URL.absoluteString
+        });
+    }
 }
 
 @end

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -137,9 +137,6 @@
 
 @end
 
-# pragma mark - UIColor(HexString)
-
-
 @implementation UIColor(HexString)
 
 + (UIColor *) colorWithHexString: (NSString *) hexString {

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -7,26 +7,36 @@
 + (CGFloat) colorComponentFrom: (NSString *) string start: (NSUInteger) start length: (NSUInteger) length;
 @end
 
-@implementation FlutterWebBrowserPlugin 
+@interface FlutterWebBrowserPlugin() <FlutterStreamHandler>
+@end
+@implementation FlutterWebBrowserPlugin {
+  FlutterEventSink _eventSink;
+  SFSafariViewController* _currentController;
+}
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  NSString* NS = @"flutter_web_browser";
+  
   FlutterMethodChannel* channel = [FlutterMethodChannel
-      methodChannelWithName:@"flutter_web_browser"
+      methodChannelWithName:NS
             binaryMessenger:[registrar messenger]];
   FlutterWebBrowserPlugin* instance = [[FlutterWebBrowserPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:channel];
+  
+  FlutterEventChannel *eventChannel = [FlutterEventChannel eventChannelWithName:[NS stringByAppendingString:@"/events"]
+                                                                binaryMessenger:[registrar messenger]];
+  [eventChannel setStreamHandler:instance];
 }
-
-
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"openWebPage" isEqualToString:call.method]) {
         NSString *url = call.arguments[@"url"];
         NSString *controlColorArg = call.arguments[@"ios_control_color"];
-        NSURL *URL = [NSURL URLWithString:url];
         UIViewController *viewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
         if (viewController.presentedViewController && !viewController.presentedViewController.isBeingDismissed ) {
             viewController = viewController.presentedViewController;
         }
+        NSURL *URL = [NSURL URLWithString:url];
         
         if (@available(iOS 9.0, *)) {
             // SafariViewController only supports http & https, calling it with anything else will cause a App crash.
@@ -59,8 +69,12 @@
                 }
                 
                 sfvc.modalPresentationCapturesStatusBarAppearance = [options[@"modalPresentationCapturesStatusBarAppearance"] boolValue];
+                
+                sfvc.delegate = self;
 
                 [viewController presentViewController:sfvc animated:YES completion:nil];
+              
+                _currentController = sfvc;
             } else {
                 [[UIApplication sharedApplication] openURL:URL];
             }
@@ -70,13 +84,62 @@
         result(nil);
     } else if ([@"warmup" isEqualToString:call.method]) {
         result([NSNumber numberWithBool:YES]);
+    } else if ([@"close" isEqualToString:call.method]) {
+      if (_currentController) {
+        [_currentController dismissViewControllerAnimated:YES completion:nil];
+
+        // SafariViewController does not emit the `safariViewControllerDidFinish` when dismissed.
+        if (_eventSink) {
+          _eventSink(@{
+            @"event": @"close",
+          });
+        }
+
+      }
+      result(nil);
     } else {
         result(FlutterMethodNotImplemented);
     }
 }
 
+#pragma mark - FlutterStreamHandler
+
+- (FlutterError *)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)events {
+  _eventSink = events;
+  
+  return nil;
+}
+
+- (FlutterError *)onCancelWithArguments:(id)arguments {
+  _eventSink = nil;
+  
+  return nil;
+}
+
+#pragma mark - SFSafariViewControllerDelegate
+
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
+  _currentController = nil;
+  
+  if (_eventSink) {
+    _eventSink(@{
+      @"event": @"close",
+    });
+  }
+}
+
+- (void)safariViewController:(SFSafariViewController *)controller initialLoadDidRedirectToURL:(NSURL *)URL {
+  if (_eventSink) {
+    _eventSink(@{
+      @"event": @"redirect",
+      @"url": URL.absoluteString
+    });
+  }
+}
+
 @end
 
+# pragma mark - UIColor(HexString)
 
 
 @implementation UIColor(HexString)

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -62,7 +63,9 @@ extension _hexColor on Color {
   }
 }
 
+/// When supported, the built-in browser can notify of various events.
 abstract class BrowserEvent {
+  // Convenience constructor.
   static BrowserEvent? fromMap(Map<String, dynamic> map) {
     if (map['event'] == 'redirect') {
       return RedirectEvent(Uri.parse(map['url']));
@@ -75,28 +78,50 @@ abstract class BrowserEvent {
   }
 }
 
+/// Describes a redirect.
 class RedirectEvent extends BrowserEvent {
   RedirectEvent(this.url);
 
+  /// New URL which is now visible.
   final Uri url;
 }
 
+/// Describes a close event (e.g. when the user closes the tab
+/// or the [FlutterWebBrowser.close] method was invoked).
 class CloseEvent extends BrowserEvent {}
 
 class FlutterWebBrowser {
-  static const NS = 'flutter_web_browser';
-  static const MethodChannel _channel = const MethodChannel(NS);
-  static const EventChannel _eventChannel = const EventChannel('$NS/events');
+  static const _NS = 'flutter_web_browser';
+  static const MethodChannel _channel = const MethodChannel(_NS);
+  static const EventChannel _eventChannel = const EventChannel('$_NS/events');
 
   static Future<bool> warmup() async {
     return await _channel.invokeMethod<bool>('warmup') ?? true;
   }
 
+  /// Closes the currently open browser.
+  ///
+  /// This function will emit a [CloseEvent], which can be observed using [events].
+  ///
+  /// Only supported on iOS. Will not do anything on other platforms.
   static Future<void> close() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
     await _channel.invokeMethod<void>('close');
   }
 
+  /// Returns a stream of browser events which were observed while it was open.
+  ///
+  /// See [CloseEvent] & [RedirectEvent] for details on the events.
+  ///
+  /// Only supported on iOS. Returns a empty stream other platforms.
   static Stream<BrowserEvent> events() {
+    if (!Platform.isIOS) {
+      return Stream.empty();
+    }
+
     return _eventChannel
         .receiveBroadcastStream()
         .map<Map<String, String>>((event) => Map<String, String>.from(event))


### PR DESCRIPTION
This way, clients can learn when the SafariViewController did a redirect or was closed (either by user or through code).

![Simulator Screen Shot - iPhone 11 - 2021-07-20 at 13 38 20](https://user-images.githubusercontent.com/269860/126325300-4fef34c2-e08a-4962-8a80-3590a2db4233.png)
