### PR TITLE
Upgrade Android Browser library and replace deprecated method usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ FlutterWebBrowser.openWebPage(
     toolbarColor: Colors.deepPurple,
     secondaryToolbarColor: Colors.green,
     navigationBarColor: Colors.amber,
-    addDefaultShareMenuItem: true,
+    shareState: CustomTabsShareState.on,
     instantAppsEnabled: true,
     showTitle: true,
     urlBarHidingEnabled: true,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.browser:browser:1.2.0'
+    implementation 'androidx.browser:browser:1.3.0'
 }

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -101,6 +101,11 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
       builder.setNavigationBarColor(Color.parseColor(navigationBarColor));
     }
 
+    String navigationBarDividerColor = (String) options.get("navigationBarDividerColor");
+    if (navigationBarDividerColor != null) {
+      builder.setNavigationBarDividerColor(Color.parseColor(navigationBarDividerColor));
+    }
+
     return builder.build();
   }
 

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -37,44 +37,48 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
 
   private void openUrl(MethodCall call, Result result) {
     if (activity == null) {
-      result.error("no_activity", "Plugin is only available within a activity context", null);
+      result.error("no_activity", "Plugin is only available within an activity context", null);
       return;
     }
     String url = call.argument("url");
     HashMap<String, Object> options = call.<HashMap<String, Object>>argument("android_options");
 
-    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+    CustomTabsIntent.Builder intentBuilder = new CustomTabsIntent.Builder();
 
-    builder.setColorScheme((Integer) options.get("colorScheme"));
+    intentBuilder.setColorScheme((Integer) options.get("colorScheme"));
+
+    CustomTabColorSchemeParams.Builder colorSchemeParamsBuilder = new CustomTabColorSchemeParams.Builder();
 
     String navigationBarColor = (String)options.get("navigationBarColor");
     if (navigationBarColor != null) {
-      builder.setNavigationBarColor(Color.parseColor(navigationBarColor));
+      colorSchemeParamsBuilder.setNavigationBarColor(Color.parseColor(navigationBarColor));
     }
 
     String toolbarColor = (String)options.get("toolbarColor");
     if (toolbarColor != null) {
-      builder.setToolbarColor(Color.parseColor(toolbarColor));
+      colorSchemeParamsBuilder.setToolbarColor(Color.parseColor(toolbarColor));
     }
 
     String secondaryToolbarColor = (String)options.get("secondaryToolbarColor");
     if (secondaryToolbarColor != null) {
-      builder.setSecondaryToolbarColor(Color.parseColor(secondaryToolbarColor));
+      colorSchemeParamsBuilder.setSecondaryToolbarColor(Color.parseColor(secondaryToolbarColor));
     }
 
-    builder.setInstantAppsEnabled((Boolean) options.get("instantAppsEnabled"));
+    CustomTabColorSchemeParams colorSchemeParams = colorSchemeParamsBuilder.build();
+    intentBuilder.setDefaultColorSchemeParams(colorSchemeParams);
 
-    if ((Boolean) options.get("addDefaultShareMenuItem")) {
-      builder.addDefaultShareMenuItem();
+    intentBuilder.setInstantAppsEnabled((Boolean) options.get("instantAppsEnabled"));
+
+    Integer shareState = (Integer)options.get("shareState");
+    if (shareState != null) {
+      intentBuilder.setShareState(shareState);
     }
 
-    builder.setShowTitle((Boolean) options.get("showTitle"));
+    intentBuilder.setShowTitle((Boolean) options.get("showTitle"));
 
-    if ((Boolean) options.get("urlBarHidingEnabled")) {
-      builder.enableUrlBarHiding();
-    }
+    intentBuilder.setUrlBarHidingEnabled((Boolean) options.get("urlBarHidingEnabled"));
 
-    CustomTabsIntent customTabsIntent = builder.build();
+    CustomTabsIntent customTabsIntent = intentBuilder.build();
     customTabsIntent.intent.setPackage(getPackageName());
     customTabsIntent.launchUrl(activity, Uri.parse(url));
 

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/MethodCallHandlerImpl.java
@@ -43,46 +43,65 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     String url = call.argument("url");
     HashMap<String, Object> options = call.<HashMap<String, Object>>argument("android_options");
 
-    CustomTabsIntent.Builder intentBuilder = new CustomTabsIntent.Builder();
+    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
 
-    intentBuilder.setColorScheme((Integer) options.get("colorScheme"));
+    builder.setColorScheme((Integer) options.get("colorScheme"));
 
-    CustomTabColorSchemeParams.Builder colorSchemeParamsBuilder = new CustomTabColorSchemeParams.Builder();
-
-    String navigationBarColor = (String)options.get("navigationBarColor");
-    if (navigationBarColor != null) {
-      colorSchemeParamsBuilder.setNavigationBarColor(Color.parseColor(navigationBarColor));
+    HashMap<String, Object> lightColorSchemeParamsMap = (HashMap<String, Object>) options.get("lightColorSchemeParams");
+    if (lightColorSchemeParamsMap != null) {
+      CustomTabColorSchemeParams lightColorSchemeParams = mapColorSchemeParams(lightColorSchemeParamsMap);
+      builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_LIGHT, lightColorSchemeParams);
     }
 
-    String toolbarColor = (String)options.get("toolbarColor");
-    if (toolbarColor != null) {
-      colorSchemeParamsBuilder.setToolbarColor(Color.parseColor(toolbarColor));
+    HashMap<String, Object> darkColorSchemeParamsMap = (HashMap<String, Object>) options.get("darkColorSchemeParams");
+    if (darkColorSchemeParamsMap != null) {
+      CustomTabColorSchemeParams darkColorSchemeParams = mapColorSchemeParams(darkColorSchemeParamsMap);
+      builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_DARK, darkColorSchemeParams);
     }
 
-    String secondaryToolbarColor = (String)options.get("secondaryToolbarColor");
-    if (secondaryToolbarColor != null) {
-      colorSchemeParamsBuilder.setSecondaryToolbarColor(Color.parseColor(secondaryToolbarColor));
+    HashMap<String, Object> defaultColorSchemeParamsMap = (HashMap<String, Object>) options.get("defaultColorSchemeParams");
+    if (defaultColorSchemeParamsMap != null) {
+      CustomTabColorSchemeParams defaultColorSchemeParams = mapColorSchemeParams(defaultColorSchemeParamsMap);
+      builder.setDefaultColorSchemeParams(defaultColorSchemeParams);
     }
 
-    CustomTabColorSchemeParams colorSchemeParams = colorSchemeParamsBuilder.build();
-    intentBuilder.setDefaultColorSchemeParams(colorSchemeParams);
+    builder.setInstantAppsEnabled((Boolean) options.get("instantAppsEnabled"));
 
-    intentBuilder.setInstantAppsEnabled((Boolean) options.get("instantAppsEnabled"));
-
-    Integer shareState = (Integer)options.get("shareState");
+    Integer shareState = (Integer) options.get("shareState");
     if (shareState != null) {
-      intentBuilder.setShareState(shareState);
+      builder.setShareState(shareState);
     }
 
-    intentBuilder.setShowTitle((Boolean) options.get("showTitle"));
+    builder.setShowTitle((Boolean) options.get("showTitle"));
 
-    intentBuilder.setUrlBarHidingEnabled((Boolean) options.get("urlBarHidingEnabled"));
+    builder.setUrlBarHidingEnabled((Boolean) options.get("urlBarHidingEnabled"));
 
-    CustomTabsIntent customTabsIntent = intentBuilder.build();
+    CustomTabsIntent customTabsIntent = builder.build();
     customTabsIntent.intent.setPackage(getPackageName());
     customTabsIntent.launchUrl(activity, Uri.parse(url));
 
     result.success(null);
+  }
+
+  private CustomTabColorSchemeParams mapColorSchemeParams(HashMap<String, Object> options) {
+    CustomTabColorSchemeParams.Builder builder = new CustomTabColorSchemeParams.Builder();
+
+    String toolbarColor = (String) options.get("toolbarColor");
+    if (toolbarColor != null) {
+      builder.setToolbarColor(Color.parseColor(toolbarColor));
+    }
+
+    String secondaryToolbarColor = (String) options.get("secondaryToolbarColor");
+    if (secondaryToolbarColor != null) {
+      builder.setSecondaryToolbarColor(Color.parseColor(secondaryToolbarColor));
+    }
+
+    String navigationBarColor = (String) options.get("navigationBarColor");
+    if (navigationBarColor != null) {
+      builder.setNavigationBarColor(Color.parseColor(navigationBarColor));
+    }
+
+    return builder.build();
   }
 
   private void warmup(Result result) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,7 +81,7 @@ class _MyAppState extends State<MyApp> {
                           toolbarColor: Colors.deepPurple,
                           secondaryToolbarColor: Colors.green,
                           navigationBarColor: Colors.amber,
-                          addDefaultShareMenuItem: true,
+                          shareState: CustomTabsShareState.on,
                           instantAppsEnabled: true,
                           showTitle: true,
                           urlBarHidingEnabled: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,9 +78,11 @@ class _MyAppState extends State<MyApp> {
                         url: "https://flutter.io/",
                         customTabsOptions: CustomTabsOptions(
                           colorScheme: CustomTabsColorScheme.dark,
-                          toolbarColor: Colors.deepPurple,
-                          secondaryToolbarColor: Colors.green,
-                          navigationBarColor: Colors.amber,
+                          darkColorSchemeParams: CustomTabsColorSchemeParams(
+                            toolbarColor: Colors.deepPurple,
+                            secondaryToolbarColor: Colors.green,
+                            navigationBarColor: Colors.amber,
+                          ),
                           shareState: CustomTabsShareState.on,
                           instantAppsEnabled: true,
                           showTitle: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,6 +82,7 @@ class _MyAppState extends State<MyApp> {
                             toolbarColor: Colors.deepPurple,
                             secondaryToolbarColor: Colors.green,
                             navigationBarColor: Colors.amber,
+                            navigationBarDividerColor: Colors.cyan,
                           ),
                           shareState: CustomTabsShareState.on,
                           instantAppsEnabled: true,

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -55,11 +55,40 @@ extension CustomTabsShareStateExtension on CustomTabsShareState {
   }
 }
 
+class CustomTabsColorSchemeParams {
+  final Color? toolbarColor;
+  final Color? secondaryToolbarColor;
+  final Color? navigationBarColor;
+
+  const CustomTabsColorSchemeParams({
+    this.toolbarColor,
+    this.secondaryToolbarColor,
+    this.navigationBarColor,
+  });
+
+  Map<String, dynamic> toMethodChannelArgumentMap({
+    Color? deprecatedToolbarColor,
+    Color? deprecatedSecondaryToolbarColor,
+    Color? deprecatedNavigationBarColor,
+  }) {
+    return {
+      'toolbarColor': (toolbarColor ?? deprecatedToolbarColor)?.hexColor,
+      'secondaryToolbarColor':
+          (secondaryToolbarColor ?? deprecatedSecondaryToolbarColor)?.hexColor,
+      'navigationBarColor':
+          (navigationBarColor ?? deprecatedNavigationBarColor)?.hexColor,
+    };
+  }
+}
+
 class CustomTabsOptions {
   final CustomTabsColorScheme colorScheme;
   final Color? toolbarColor;
   final Color? secondaryToolbarColor;
   final Color? navigationBarColor;
+  final CustomTabsColorSchemeParams? lightColorSchemeParams;
+  final CustomTabsColorSchemeParams? darkColorSchemeParams;
+  final CustomTabsColorSchemeParams? defaultColorSchemeParams;
   final bool instantAppsEnabled;
   final bool? addDefaultShareMenuItem;
   final CustomTabsShareState? shareState;
@@ -68,9 +97,15 @@ class CustomTabsOptions {
 
   const CustomTabsOptions({
     this.colorScheme = CustomTabsColorScheme.system,
-    this.toolbarColor,
-    this.secondaryToolbarColor,
-    this.navigationBarColor,
+    @Deprecated('Use defaultColorSchemeParams.toolbarColor instead')
+        this.toolbarColor,
+    @Deprecated('Use defaultColorSchemeParams.secondaryToolbarColor instead')
+        this.secondaryToolbarColor,
+    @Deprecated('Use defaultColorSchemeParams.navigationBarColor instead')
+        this.navigationBarColor,
+    this.lightColorSchemeParams,
+    this.darkColorSchemeParams,
+    this.defaultColorSchemeParams,
     this.instantAppsEnabled = false,
     @Deprecated('Use shareState instead') this.addDefaultShareMenuItem,
     this.shareState,
@@ -157,6 +192,13 @@ class FlutterWebBrowser {
     SafariViewControllerOptions safariVCOptions =
         const SafariViewControllerOptions(),
   }) {
+    final CustomTabsColorSchemeParams customTabsDefaultColorSchemeParams =
+        customTabsOptions.defaultColorSchemeParams ??
+            CustomTabsColorSchemeParams(
+              toolbarColor: customTabsOptions.toolbarColor,
+              secondaryToolbarColor: customTabsOptions.secondaryToolbarColor,
+              navigationBarColor: customTabsOptions.navigationBarColor,
+            );
     final CustomTabsShareState customTabsShareState =
         customTabsOptions.shareState ??
             CustomTabsShareStateExtension.fromAddDefaultShareMenuItem(
@@ -169,10 +211,12 @@ class FlutterWebBrowser {
       "url": url,
       'android_options': {
         'colorScheme': customTabsOptions.colorScheme.index,
-        'navigationBarColor': customTabsOptions.navigationBarColor?.hexColor,
-        'toolbarColor': customTabsOptions.toolbarColor?.hexColor,
-        'secondaryToolbarColor':
-            customTabsOptions.secondaryToolbarColor?.hexColor,
+        'lightColorSchemeParams': customTabsOptions.lightColorSchemeParams
+            ?.toMethodChannelArgumentMap(),
+        'darkColorSchemeParams': customTabsOptions.darkColorSchemeParams
+            ?.toMethodChannelArgumentMap(),
+        'defaultColorSchemeParams':
+            customTabsDefaultColorSchemeParams.toMethodChannelArgumentMap(),
         'instantAppsEnabled': customTabsOptions.instantAppsEnabled,
         'shareState': customTabsShareState.index,
         'showTitle': customTabsOptions.showTitle,

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -40,6 +40,21 @@ enum CustomTabsShareState {
   off, // 0x00000002
 }
 
+extension CustomTabsShareStateExtension on CustomTabsShareState {
+  static CustomTabsShareState? fromAddDefaultShareMenuItem(
+      {bool? addDefaultShareMenuItem}) {
+    if (addDefaultShareMenuItem != null) {
+      if (addDefaultShareMenuItem) {
+        return CustomTabsShareState.on;
+      } else {
+        return CustomTabsShareState.off;
+      }
+    }
+
+    return null;
+  }
+}
+
 class CustomTabsOptions {
   final CustomTabsColorScheme colorScheme;
   final Color? toolbarColor;
@@ -47,7 +62,7 @@ class CustomTabsOptions {
   final Color? navigationBarColor;
   final bool instantAppsEnabled;
   final bool? addDefaultShareMenuItem;
-  final CustomTabsShareState shareState;
+  final CustomTabsShareState? shareState;
   final bool showTitle;
   final bool urlBarHidingEnabled;
 
@@ -58,7 +73,7 @@ class CustomTabsOptions {
     this.navigationBarColor,
     this.instantAppsEnabled = false,
     @Deprecated('Use shareState instead') this.addDefaultShareMenuItem,
-    this.shareState = CustomTabsShareState.default_,
+    this.shareState,
     this.showTitle = false,
     this.urlBarHidingEnabled = false,
   });
@@ -142,6 +157,14 @@ class FlutterWebBrowser {
     SafariViewControllerOptions safariVCOptions =
         const SafariViewControllerOptions(),
   }) {
+    final CustomTabsShareState customTabsShareState =
+        customTabsOptions.shareState ??
+            CustomTabsShareStateExtension.fromAddDefaultShareMenuItem(
+              addDefaultShareMenuItem:
+                  customTabsOptions.addDefaultShareMenuItem,
+            ) ??
+            CustomTabsShareState.default_;
+
     return _channel.invokeMethod('openWebPage', {
       "url": url,
       'android_options': {
@@ -151,10 +174,7 @@ class FlutterWebBrowser {
         'secondaryToolbarColor':
             customTabsOptions.secondaryToolbarColor?.hexColor,
         'instantAppsEnabled': customTabsOptions.instantAppsEnabled,
-        'shareState': (_convertAddDefaultShareMenuItemToShareState(
-                    customTabsOptions.addDefaultShareMenuItem) ??
-                customTabsOptions.shareState)
-            .index,
+        'shareState': customTabsShareState.index,
         'showTitle': customTabsOptions.showTitle,
         'urlBarHidingEnabled': customTabsOptions.urlBarHidingEnabled,
       },
@@ -170,19 +190,5 @@ class FlutterWebBrowser {
         'dismissButtonStyle': safariVCOptions.dismissButtonStyle?.index,
       },
     });
-  }
-
-  static CustomTabsShareState? _convertAddDefaultShareMenuItemToShareState(
-    bool? addDefaultShareMenuItem,
-  ) {
-    if (addDefaultShareMenuItem != null) {
-      if (addDefaultShareMenuItem) {
-        return CustomTabsShareState.on;
-      } else {
-        return CustomTabsShareState.off;
-      }
-    }
-
-    return null;
   }
 }

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -59,11 +59,13 @@ class CustomTabsColorSchemeParams {
   final Color? toolbarColor;
   final Color? secondaryToolbarColor;
   final Color? navigationBarColor;
+  final Color? navigationBarDividerColor;
 
   const CustomTabsColorSchemeParams({
     this.toolbarColor,
     this.secondaryToolbarColor,
     this.navigationBarColor,
+    this.navigationBarDividerColor,
   });
 
   Map<String, dynamic> toMethodChannelArgumentMap({
@@ -77,6 +79,7 @@ class CustomTabsColorSchemeParams {
           (secondaryToolbarColor ?? deprecatedSecondaryToolbarColor)?.hexColor,
       'navigationBarColor':
           (navigationBarColor ?? deprecatedNavigationBarColor)?.hexColor,
+      'navigationBarDividerColor': navigationBarDividerColor?.hexColor,
     };
   }
 }

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -34,13 +34,20 @@ enum CustomTabsColorScheme {
   dark, // 0x00000002
 }
 
+enum CustomTabsShareState {
+  default_, // 0x00000000
+  on, // 0x00000001
+  off, // 0x00000002
+}
+
 class CustomTabsOptions {
   final CustomTabsColorScheme colorScheme;
   final Color? toolbarColor;
   final Color? secondaryToolbarColor;
   final Color? navigationBarColor;
   final bool instantAppsEnabled;
-  final bool addDefaultShareMenuItem;
+  final bool? addDefaultShareMenuItem;
+  final CustomTabsShareState shareState;
   final bool showTitle;
   final bool urlBarHidingEnabled;
 
@@ -50,7 +57,8 @@ class CustomTabsOptions {
     this.secondaryToolbarColor,
     this.navigationBarColor,
     this.instantAppsEnabled = false,
-    this.addDefaultShareMenuItem = false,
+    @Deprecated('Use shareState instead') this.addDefaultShareMenuItem,
+    this.shareState = CustomTabsShareState.default_,
     this.showTitle = false,
     this.urlBarHidingEnabled = false,
   });
@@ -143,7 +151,10 @@ class FlutterWebBrowser {
         'secondaryToolbarColor':
             customTabsOptions.secondaryToolbarColor?.hexColor,
         'instantAppsEnabled': customTabsOptions.instantAppsEnabled,
-        'addDefaultShareMenuItem': customTabsOptions.addDefaultShareMenuItem,
+        'shareState': (_convertAddDefaultShareMenuItemToShareState(
+                    customTabsOptions.addDefaultShareMenuItem) ??
+                customTabsOptions.shareState)
+            .index,
         'showTitle': customTabsOptions.showTitle,
         'urlBarHidingEnabled': customTabsOptions.urlBarHidingEnabled,
       },
@@ -159,5 +170,19 @@ class FlutterWebBrowser {
         'dismissButtonStyle': safariVCOptions.dismissButtonStyle?.index,
       },
     });
+  }
+
+  static CustomTabsShareState? _convertAddDefaultShareMenuItemToShareState(
+    bool? addDefaultShareMenuItem,
+  ) {
+    if (addDefaultShareMenuItem != null) {
+      if (addDefaultShareMenuItem) {
+        return CustomTabsShareState.on;
+      } else {
+        return CustomTabsShareState.off;
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Upgrading the [Jetpack Browser library](https://developer.android.com/jetpack/androidx/releases/browser) for Android fixes not being able to show a share button in Firefox. This is due to Firefox only caring about `setShareState`, not the deprecated `addDefaultShareMenuItem`. To maintain backwards-compatibility I've kept the latter field in this package but marked it as deprecated.

Note that `CustomTabsShareState.default_` has a funny looking trailing underscore because `default` is a Dart keyword.