### PR TITLE
Modal presentation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.17.1]
+* Add option to define `modalPresentationStyle` in `SafariViewControllerOptions`. This allows to change the Presentation Style based on https://developer.apple.com/documentation/uikit/uimodalpresentationstyle
+
 ## [0.17.0]
 * Upgrade Android broswer library for Android 12 compatibility
 * Adjust Android compile SDK version to 31

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -107,6 +107,7 @@ class _MyAppState extends State<MyApp> {
                           dismissButtonStyle:
                               SafariViewControllerDismissButtonStyle.close,
                           modalPresentationCapturesStatusBarAppearance: true,
+                          modalPresentationStyle: UIModalPresentationStyle.popover,
                         ),
                       );
                     },

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -158,8 +158,10 @@
                          forKey:@"overFullScreen"];
   [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationOverCurrentContext]
                          forKey:@"overCurrentContext"];
-  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationPopover]
-                         forKey:@"popover"];
+  if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+    [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationPopover]
+                        forKey:@"popover"];
+  }
 
   NSNumber *presentationStyle = [presentationStyles objectForKey:input];
   if (presentationStyle != nil) {

--- a/ios/Classes/FlutterWebBrowserPlugin.m
+++ b/ios/Classes/FlutterWebBrowserPlugin.m
@@ -70,6 +70,10 @@
                 
                 sfvc.modalPresentationCapturesStatusBarAppearance = [options[@"modalPresentationCapturesStatusBarAppearance"] boolValue];
                 
+                NSString *presentationStyle = options[@"modalPresentationStyle"];
+
+                [self setPresentationStyleFromInput:sfvc input:presentationStyle];
+                
                 sfvc.delegate = self;
 
                 [viewController presentViewController:sfvc animated:YES completion:nil];
@@ -133,6 +137,36 @@
             @"url": URL.absoluteString
         });
     }
+}
+
+- (void)setPresentationStyleFromInput:(UIViewController *)viewController input:(NSString *)input {
+  NSMutableDictionary *presentationStyles = [[NSMutableDictionary alloc] init];
+
+  if (@available(iOS 13.0, *)) {
+    [presentationStyles setObject:@"automatic"
+                           forKey:[NSNumber numberWithInt:UIModalPresentationAutomatic]];
+  }
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationFullScreen]
+                         forKey:@"fullScreen"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationPageSheet]
+                         forKey:@"pageSheet"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationFormSheet]
+                         forKey:@"formSheet"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationCurrentContext]
+                         forKey:@"currentContext"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationOverFullScreen]
+                         forKey:@"overFullScreen"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationOverCurrentContext]
+                         forKey:@"overCurrentContext"];
+  [presentationStyles setObject:[NSNumber numberWithInt:UIModalPresentationPopover]
+                         forKey:@"popover"];
+
+  NSNumber *presentationStyle = [presentationStyles objectForKey:input];
+  if (presentationStyle != nil) {
+    viewController.modalPresentationStyle = presentationStyle.intValue;
+  } else {
+      viewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
+  }
 }
 
 @end

--- a/lib/flutter_web_browser.dart
+++ b/lib/flutter_web_browser.dart
@@ -17,6 +17,7 @@ class SafariViewControllerOptions {
   final Color? preferredControlTintColor;
   final bool modalPresentationCapturesStatusBarAppearance;
   final SafariViewControllerDismissButtonStyle? dismissButtonStyle;
+  final UIModalPresentationStyle modalPresentationStyle;
 
   const SafariViewControllerOptions({
     this.barCollapsingEnabled = false,
@@ -25,6 +26,7 @@ class SafariViewControllerOptions {
     this.preferredControlTintColor,
     this.modalPresentationCapturesStatusBarAppearance = false,
     this.dismissButtonStyle,
+    this.modalPresentationStyle = UIModalPresentationStyle.overFullScreen,
   });
 }
 
@@ -235,7 +237,45 @@ class FlutterWebBrowser {
         'modalPresentationCapturesStatusBarAppearance':
             safariVCOptions.modalPresentationCapturesStatusBarAppearance,
         'dismissButtonStyle': safariVCOptions.dismissButtonStyle?.index,
+        'modalPresentationStyle': safariVCOptions.modalPresentationStyle.name,
       },
     });
   }
+}
+
+/// Modal presentation styles available when presenting view controllers.
+///
+/// For more info see
+/// https://developer.apple.com/documentation/uikit/uimodalpresentationstyle
+enum UIModalPresentationStyle {
+  /// The default presentation style chosen by the system.
+  automatic,
+
+  /// A presentation style that indicates no adaptations should be made.
+  /// Not working
+  none,
+
+  /// A presentation style in which the presented view covers the screen.
+  fullScreen,
+
+  /// A presentation style that partially covers the underlying content.
+  pageSheet,
+
+  /// A presentation style that displays the content centered in the screen.
+  formSheet,
+
+  /// A presentation style where the content is displayed over another view controller’s content.
+  currentContext,
+
+  /// A view presentation style in which the presented view covers the screen.
+  overFullScreen,
+
+  /// A presentation style where the content is displayed over another view controller’s content.
+  overCurrentContext,
+
+  /// A presentation style where the content is displayed in a popover view.
+  popover,
+
+  /// A presentation style that blurs the underlying content before displaying new content in a full-screen presentation.
+  blurOverFullScreen,
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_web_browser
 description: A flutter plugin project to open a web page with Chrome Custom Tabs & SFSafariViewController.
 homepage: https://github.com/victorbonnet/flutter_web_browser
-version: 0.17.0
+version: 0.17.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Added an options to show the Safari View Controller with different Modal Presentation Styles. This should at least cover the case on iOS for #41 

I made it so the default behaviour is still the same to how it was thus not introducing a visual breaking change