### PR TITLE
Update build.gradle to add support for Android Gradle Plugin 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    if (project.android.hasProperty("namespace")) {
+        namespace("dev.vbonnet.flutterwebbrowser")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
When building my app using this library with Gradle 8.1 and AGP 8.0.1, I encountered this error:

A problem occurred configuring project ':flutter_web_browser'.

Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
Namespace not specified.

Since this project still uses AGP 3.5 and requested property added in AGP 7.3 - I added it in a backward compatible way.