### PR TITLE
🐛 fix: remove references to deprecated v1 embedding classes (fixes #52)

### DIFF
--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/FlutterWebBrowserPlugin.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/FlutterWebBrowserPlugin.java
@@ -8,7 +8,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.ViewDestroyListener;
 
 /** FlutterWebBrowserPlugin */
 public class FlutterWebBrowserPlugin implements FlutterPlugin, ActivityAware {

--- a/android/src/main/java/dev/vbonnet/flutterwebbrowser/FlutterWebBrowserPlugin.java
+++ b/android/src/main/java/dev/vbonnet/flutterwebbrowser/FlutterWebBrowserPlugin.java
@@ -8,31 +8,13 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.common.PluginRegistry.ViewDestroyListener;
-import io.flutter.view.FlutterNativeView;
 
 /** FlutterWebBrowserPlugin */
 public class FlutterWebBrowserPlugin implements FlutterPlugin, ActivityAware {
 
   private MethodChannel methodChannel;
   private MethodCallHandlerImpl methodCallHandler;
-
-  public static void registerWith(Registrar registrar) {
-    final FlutterWebBrowserPlugin plugin = new FlutterWebBrowserPlugin();
-    plugin.startListening(registrar.messenger());
-    if (registrar.activity() != null) {
-      plugin.setActivity(registrar.activity());
-    }
-    registrar.addViewDestroyListener(
-        new ViewDestroyListener() {
-          @Override
-          public boolean onViewDestroy(FlutterNativeView view) {
-            plugin.stopListening();
-            return false;
-          }
-        });
-  }
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {


### PR DESCRIPTION
Remove references to no longer supported v1 embedding classes, in order to support Flutter `3.29.0`+